### PR TITLE
add /my-polls to allowed paths when creating user

### DIFF
--- a/src/Components/Forms/SignUp.js
+++ b/src/Components/Forms/SignUp.js
@@ -150,7 +150,7 @@ export default class SignUp extends Component {
       role: 'Premium',
       redirect: '/',
       status: 'Active',
-      allowedPaths: ['/my-questionnaires', '/create-questionnaire'],
+      allowedPaths: ['/my-questionnaires', '/create-questionnaire', '/my-polls'],
       excludedPaths: [],
     };
 


### PR DESCRIPTION
- add /my-polls when registering users

this allows for the menu item my-polls to be vissible when logged in