### PR TITLE
	increes size of inputs and buttons

### DIFF
--- a/src/Assets/Styles/Components/DataTable/Filters.scss
+++ b/src/Assets/Styles/Components/DataTable/Filters.scss
@@ -22,6 +22,7 @@
             text-align: left;
             input {
               width: 100%;
+              font-size: 1.2em;
             }
             width: 100%;
             @media (min-width: 769px) {

--- a/src/Assets/Styles/Components/Form.scss
+++ b/src/Assets/Styles/Components/Form.scss
@@ -71,6 +71,8 @@ label {
   &:focus, &:active:focus {
     box-shadow: none;
   }
+  height: fit-content;
+  font-size: 1.2em;
 }
 .btn {
   &:focus, &:focus:active {

--- a/src/Components/Forms/Question/CreateQuestion.js
+++ b/src/Components/Forms/Question/CreateQuestion.js
@@ -46,6 +46,7 @@ export default class CreateQuestion extends Component {
               content="X"
               value={0}
               onClick={this.removeOption}
+              size="large"
             />
           </Form.Group>,
           <Form.Group
@@ -63,6 +64,7 @@ export default class CreateQuestion extends Component {
               content="X"
               value={1}
               onClick={this.removeOption}
+              size="large"
             />
           </Form.Group>,
         ],
@@ -97,6 +99,7 @@ export default class CreateQuestion extends Component {
               content="X"
               value={index}
               onClick={this.removeOption}
+              size="large"
             />
           </Form.Group>);
         oldOptions.push(oldOption);
@@ -177,6 +180,7 @@ export default class CreateQuestion extends Component {
               content="X"
               value={this.state.options.length}
               onClick={this.removeOption}
+              size="large"
             />
           </Form.Group>,
         ],
@@ -201,6 +205,7 @@ export default class CreateQuestion extends Component {
               content="X"
               value={0}
               onClick={this.removeOption}
+              size="large"
             />
           </Form.Group>,
         ],
@@ -247,6 +252,7 @@ export default class CreateQuestion extends Component {
             content="X"
             value={index}
             onClick={this.removeOption}
+            size="large"
           />
         </Form.Group>);
       return newOption;
@@ -263,7 +269,7 @@ export default class CreateQuestion extends Component {
         <Redirect to="/my-questionnaires" />
         }
         <div>
-          <Form id="creat-question-form">
+          <Form id="creat-question-form" size="large">
             <div className="padding-tb-2">
               <Form.Group
                 className="center-content padding-b-1"
@@ -274,11 +280,10 @@ export default class CreateQuestion extends Component {
                   onChange={this.handleChange}
                   name="question"
                   value={this.state.question}
-                  placeholder="Question title"
-                  required
+                  placeholder="Question"
                   type="text"
                   width={11}
-                  label="Question title"
+                  label="Question"
                 />
                 <Form.Select label="Type" name="type" options={types} width={1} defaultValue={this.state.type} onChange={this.handleChange} />
               </Form.Group>
@@ -292,6 +297,7 @@ export default class CreateQuestion extends Component {
             icon="plus"
             labelPosition="left"
             onClick={this.addOption}
+            size="large"
           />
         </div>
         <Button
@@ -299,6 +305,7 @@ export default class CreateQuestion extends Component {
           content={this.props.question ? 'Update' : 'Add'}
           attached="bottom"
           onClick={this.props.question ? this.updateQuestion : this.createQuestion}
+          size="large"
         />
       </div>
     );

--- a/src/Components/Forms/Question/CreateQuestionnaire.js
+++ b/src/Components/Forms/Question/CreateQuestionnaire.js
@@ -151,6 +151,7 @@ export default class CreateQuestionnaire extends Component {
               content="Create"
               floated="right"
               icon="arrow right"
+              size="large"
               attached="bottom"
               labelPosition="right"
               onClick={this.createQuestionnaire}
@@ -165,6 +166,7 @@ export default class CreateQuestionnaire extends Component {
             <h2>{this.props.activeQuestionnaire.title}</h2>
             <Button
               basic
+              size="large"
               content="Edit"
               onClick={this.toggleEdit}
             />
@@ -195,6 +197,7 @@ export default class CreateQuestionnaire extends Component {
             </Form>
             <Button
               basic
+              size="large"
               content="Update"
               attached="bottom"
               onClick={this.updateQuestionnaire}
@@ -219,6 +222,7 @@ export default class CreateQuestionnaire extends Component {
           !this.state.editing &&
           <Button
             basic
+            size="large"
             content="Add question"
             icon="plus"
             labelPosition="right"
@@ -234,6 +238,7 @@ export default class CreateQuestionnaire extends Component {
           <div className="margin-tb-1">
             <Button
               basic
+              size="large"
               content="Done"
               attached="bottom"
               onClick={this.triggerRedirect}

--- a/src/Components/Forms/Question/CreateQuestionnaire.js
+++ b/src/Components/Forms/Question/CreateQuestionnaire.js
@@ -125,7 +125,7 @@ export default class CreateQuestionnaire extends Component {
         {
           !this.props.activeQuestionnaire.id &&
           <div className="min-height">
-            <Form id="creat-question-form">
+            <Form id="creat-question-form" size="large">
               <div className="padding-tb-2">
                 <Form.Group
                   className="center-content padding-b-1"

--- a/src/Components/Forms/Question/Option/CreateOption.js
+++ b/src/Components/Forms/Question/Option/CreateOption.js
@@ -33,7 +33,6 @@ export default class CreateOption extends Component {
         name={this.props.name}
         value={this.state[this.props.name]}
         placeholder="Alternative"
-        required
         type="text"
         label="Alternative"
       />

--- a/src/Components/Forms/SignIn.js
+++ b/src/Components/Forms/SignIn.js
@@ -130,6 +130,7 @@ export default class SignIn extends Component {
             color="orange"
             content="SIGN IN"
             type="submit"
+            size="large"
             disabled={this.state.isSigningIn}
           />
 

--- a/src/Components/Forms/SignUp.js
+++ b/src/Components/Forms/SignUp.js
@@ -189,6 +189,7 @@ export default class SignUp extends Component {
             color="orange"
             content="SIGN UP"
             type="submit"
+            size="large"
             disabled={this.state.isSigningUp}
           />
 

--- a/src/Components/Poll/Listable/ListablePoll.js
+++ b/src/Components/Poll/Listable/ListablePoll.js
@@ -41,8 +41,8 @@ export default class ListablePoll extends Component {
         <Accordion.Content active={this.props.activeIndex === this.props.index}>
           <div className="center-content-column padding-1">
             <div className="center content-row">
-              <Button basic onClick={this.viewResults} content="View Result" />
-              <Button basic onClick={this.deletePoll} content="Delete" />
+              <Button basic size="large" onClick={this.viewResults} content="View Result" />
+              <Button basic size="large" onClick={this.deletePoll} content="Delete" />
             </div>
           </div>
         </Accordion.Content>

--- a/src/Components/Questionnaires/Questionnaire.js
+++ b/src/Components/Questionnaires/Questionnaire.js
@@ -110,12 +110,12 @@ export default class Questionnaire extends Component {
           <div className="center-content-column padding-1">
             <div className="center content-row">
               <button
-                className="ui blue basic button"
+                className="ui blue basic button large"
                 onClick={this.state.active ? this.viewResults : this.editQuestionnaire}
               > {this.state.active ? 'Live results' : 'Edit' }
               </button>
               { this.state.hasQuestions && this.state.hasOptions &&
-                <button className="ui orange basic button" onClick={this.togglePoll}>{ this.state.active ? 'End' : 'Activate' }</button>
+                <button className="ui orange basic button large" onClick={this.togglePoll}>{ this.state.active ? 'End' : 'Activate' }</button>
               }
 
             </div>
@@ -125,7 +125,7 @@ export default class Questionnaire extends Component {
               <Modal
                 className="scrolling"
                 trigger={<Button
-                  className="ui black basic button"
+                  className="ui black basic button large"
 
                 >Delete
                          </Button>}
@@ -158,12 +158,12 @@ export default class Questionnaire extends Component {
                   text={this.state.value}
                   onCopy={() => this.setState({ copied: true })}
                 >
-                  <button className="ui basic button yellow" >Link</button>
+                  <button className="ui basic button yellow large" >Link</button>
                 </CopyToClipboard>
 
                 <Modal
                   className="scrolling"
-                  trigger={<Button onClick={this.handleModal} className="ui basic button yellow" >QR-Code</Button>}
+                  trigger={<Button size="large" onClick={this.handleModal} className="ui basic button yellow" >QR-Code</Button>}
                   open={this.state.modalOpen}
                 >
                   <Modal.Header>

--- a/src/Components/Questions/ListableQuestion.js
+++ b/src/Components/Questions/ListableQuestion.js
@@ -50,11 +50,12 @@ export default class  ListableQuestion extends Component {
         { !this.state.isBeingEdited &&
         <div>
         <h3>{this.props.question.name}</h3>
-        <Button basic color="blue" content="Edit" onClick={this.toggleEditQuestion}  disabled={this.props.editingQuestionnaire} />
+        <Button basic size="large" color="blue" content="Edit" onClick={this.toggleEditQuestion}  disabled={this.props.editingQuestionnaire} />
         {this.state.delete &&
         <Modal
         className="scrolling"
         trigger={<Button
+          size="large"
           className="ui red basic button"
           disabled={this.props.editingQuestionnaire}
         >Delete
@@ -71,10 +72,10 @@ export default class  ListableQuestion extends Component {
 
         </Modal.Content>
         <Modal.Actions>
-          <Button basic color="red" inverted onClick={this.handleClose}>
+          <Button size="large" basic color="red" inverted onClick={this.handleClose}>
             <Icon name="remove" /> No
           </Button>
-          <Button color="green" inverted onClick={this.toggleDeleteQuestion}>
+          <Button size="large" color="green" inverted onClick={this.toggleDeleteQuestion}>
             <Icon name="checkmark" /> Yes
           </Button>
         </Modal.Actions>

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -42,12 +42,12 @@ export default class Result extends Component {
     const buttons = [];
     let button;
     if (this.state.currentQuestion !== 0) {
-      button = <Button key={uuidv4()} content="previus" onClick={this.prevQuestion} basic floated="left" />;
+      button = <Button size="large" key={uuidv4()} content="previus" onClick={this.prevQuestion} basic floated="left" />;
       buttons.push(button);
     }
     if (this.props.poll.questionnaire) {
       if (this.state.currentQuestion !== (this.props.poll.questionnaire.questions.length - 1)) {
-        button = <Button key={uuidv4()} content="next" onClick={this.nextQuestion} basic floated="right" />;
+        button = <Button size="large" key={uuidv4()} content="next" onClick={this.nextQuestion} basic floated="right" />;
         buttons.push(button);
       }
     }

--- a/src/Views/Site/Home.js
+++ b/src/Views/Site/Home.js
@@ -13,14 +13,14 @@ export default class Home extends Component {
             <div className="ui two column centered grid stackable columns">
               <div className="two column centered row">
                 <div className="two column aligned">
-                  <Button href="/sign-in" fluid inverted color="orange">SIGN IN</Button>
+                  <Button href="/sign-in" fluid inverted color="orange" size="large">SIGN IN</Button>
                 </div>
                 <div className="two column aligned">
-                  <Button href="/sign-up" fluid inverted color="orange">SIGN UP</Button>
+                  <Button href="/sign-up" fluid inverted color="orange" size="large">SIGN UP</Button>
                 </div>
               </div>
               <div className="two column middle aligned">
-                <Button href="/howdoesitwork" fluid inverted color="orange">HOW DOES IT WORK?</Button>
+                <Button href="/howdoesitwork" fluid inverted color="orange" size="large">HOW DOES IT WORK?</Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- add size big to all sematic-ui buttons and forms
- add height fit-content and font-size: 1.2em to .form-control class

this increases the font size of all input-fields which hopefully will prevent the browser on some mobile devices from zooming in when selecting a input field. Has to be tested with mobile device to make sure it works but perliminery test with XCodes simulators seams to work well